### PR TITLE
Fix index.html JS paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,8 +117,8 @@ body {
 </form>
 
 <!-- Load external js resources -->
-<script src="d3/d3.js" charset="utf-8"></script>
-<script src="build/flog2.js"></script>
+<script src="d3/3.5.5/d3.js" charset="utf-8"></script>
+<script src="build/2.0/flog2.js"></script>
 <!--script src="src/Flog2.js"></script>
 <script src="src/Flog2.DataFormatter.js"></script>
 <script src="src/Flog2.Renderer.js"></script>


### PR DESCRIPTION
The index files in the `examples` folder have the right paths to Javascript files, but the root `index.html` file does not.